### PR TITLE
Fix IL2CPP OpenXR hook trampoline

### DIFF
--- a/Runtime/Utils/FeatureBase.cs
+++ b/Runtime/Utils/FeatureBase.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using AOT;
 using UnityEngine;
@@ -11,6 +12,64 @@ using UnityEngine.XR.OpenXR.NativeTypes;
 
 namespace OpenXR.Extensions
 {
+    internal static class GetInstanceProcAddrInterceptor
+    {
+        private static readonly del_xrGetInstanceProcAddr s_Callback = Intercepted_xrGetInstanceProcAddr;
+        private static readonly List<del_xrGetInstanceProcAddr> s_Handlers = new List<del_xrGetInstanceProcAddr>();
+        private static del_xrGetInstanceProcAddr s_GetInstanceProcAddr;
+        private static IntPtr s_CallbackPointer;
+
+        public static del_xrGetInstanceProcAddr GetInstanceProcAddr => s_GetInstanceProcAddr;
+
+        public static IntPtr Hook(IntPtr xrGetInstanceProcAddr, del_xrGetInstanceProcAddr handler)
+        {
+            if (!s_Handlers.Contains(handler))
+            {
+                s_Handlers.Add(handler);
+            }
+
+            if (s_CallbackPointer == IntPtr.Zero)
+            {
+                s_CallbackPointer = Marshal.GetFunctionPointerForDelegate(s_Callback);
+            }
+
+            if (xrGetInstanceProcAddr != s_CallbackPointer && s_GetInstanceProcAddr == null)
+            {
+                s_GetInstanceProcAddr = Marshal.GetDelegateForFunctionPointer<del_xrGetInstanceProcAddr>(
+                    xrGetInstanceProcAddr);
+            }
+
+            return s_CallbackPointer;
+        }
+
+        public static void Unhook(del_xrGetInstanceProcAddr handler)
+        {
+            s_Handlers.Remove(handler);
+            if (s_Handlers.Count == 0)
+            {
+                s_GetInstanceProcAddr = null;
+            }
+        }
+
+        [MonoPInvokeCallback(typeof(del_xrGetInstanceProcAddr))]
+        private static XrResult Intercepted_xrGetInstanceProcAddr(ulong instance, string originFunctionName,
+            ref IntPtr originFunctionPointer)
+        {
+            if (s_GetInstanceProcAddr == null)
+            {
+                return (XrResult)0;
+            }
+
+            XrResult result = s_GetInstanceProcAddr(instance, originFunctionName, ref originFunctionPointer);
+            del_xrGetInstanceProcAddr[] handlers = s_Handlers.ToArray();
+            foreach (del_xrGetInstanceProcAddr handler in handlers)
+            {
+                handler.Invoke(instance, originFunctionName, ref originFunctionPointer);
+            }
+            return result;
+        }
+    }
+
     public abstract class FeatureBase<Feature> : OpenXRFeature where Feature : OpenXRFeature
     {
         protected static ulong XrInstance = 0;
@@ -18,15 +77,15 @@ namespace OpenXR.Extensions
 
         protected static del_xrGetInstanceProcAddr GetInstanceProcAddr;
         protected static del_xrGetInstanceProcAddr OnGetInstanceProcAddr;
+        private static readonly del_xrGetInstanceProcAddr s_OnGetInstanceProcAddr = HandleGetInstanceProcAddr;
 
         public static bool FeatureEnabled => OpenXRSettings.Instance.GetFeature<Feature>().enabled;
 
-        [MonoPInvokeCallback(typeof(del_xrGetInstanceProcAddr))]
-        protected static XrResult Intercepted_xrGetInstanceProcAddr(ulong instance, string originFunctionName, ref IntPtr originFunctionPointer)
+        private static XrResult HandleGetInstanceProcAddr(ulong instance, string originFunctionName,
+            ref IntPtr originFunctionPointer)
         {
-            var result = GetInstanceProcAddr(instance, originFunctionName, ref originFunctionPointer);
             OnGetInstanceProcAddr?.Invoke(instance, originFunctionName, ref originFunctionPointer);
-            return result;
+            return (XrResult)0;
         }
 
         protected static void InterceptFunction<T>(string functionNameToReplace, T replacementFunctionDelegate, ref T originFunctionDelegate, string originFunctionName, ref IntPtr originFunctionPointer)
@@ -105,13 +164,16 @@ namespace OpenXR.Extensions
             XrInstance = 0;
             GetInstanceProcAddr = null;
             OnGetInstanceProcAddr = null;
+            GetInstanceProcAddrInterceptor.Unhook(s_OnGetInstanceProcAddr);
             UnhookFunctions();
         }
 
         protected override IntPtr HookGetInstanceProcAddr(IntPtr xrGetInstanceProcAddr)
         {
-            InterceptFunction("xrGetInstanceProcAddr", Intercepted_xrGetInstanceProcAddr, ref GetInstanceProcAddr, "xrGetInstanceProcAddr",  ref xrGetInstanceProcAddr);
-            return xrGetInstanceProcAddr;
+            IntPtr hookedGetInstanceProcAddr = GetInstanceProcAddrInterceptor.Hook(
+                xrGetInstanceProcAddr, s_OnGetInstanceProcAddr);
+            GetInstanceProcAddr = GetInstanceProcAddrInterceptor.GetInstanceProcAddr;
+            return hookedGetInstanceProcAddr;
         }
         #endregion
     }


### PR DESCRIPTION
Fixes an Android IL2CPP launch failure in Unity OpenXR Extensions.

  On Quest, Open Brush was hanging during launch because OpenXR initialization threw NotSupportedException when IL2CPP
  tried to marshal FeatureBase<T>.Intercepted_xrGetInstanceProcAddr. Although the method had MonoPInvokeCallback, it
  lived inside a generic class, so the closed generic feature types still failed at runtime.

  This moves the xrGetInstanceProcAddr trampoline into a non-generic helper with a single MonoPInvokeCallback entry
  point, while keeping per-feature handlers registered from FeatureBase<T>. That lets multiple OpenXR extension features
  hook function lookup without requiring IL2CPP to marshal a generic-class callback.